### PR TITLE
Brodcast status events to all clients

### DIFF
--- a/musikserver/spotbox.py
+++ b/musikserver/spotbox.py
@@ -3,15 +3,16 @@ from time import sleep
 from queue import Queue, Empty
 import spotify
 
-class Spotbox(Thread):
+class Spotbox:
     def __init__(self, username, password):
-        super(Spotbox, self).__init__()
         self.session = spotify.Session()
         self.session.login(username, password)
         self.cmd_queue = Queue()
+        self.status_queue = Queue()
         self.running = True
         self.track = None
         self.audio = spotify.AlsaSink(self.session)
+        self.playing = False
 
     def run(self):
         timeout = 0
@@ -30,14 +31,27 @@ class Spotbox(Thread):
         if cmd[0] == "track":
             self.track = self.session.get_link(cmd[1]).as_track()
         elif cmd[0] == "play":
-            self.session.player.play()
+            self.playing = True
         elif cmd[0] == "pause":
-            self.session.player.pause()
+            self.playing = False
 
     def process(self):
         if self.track != None and self.track.is_loaded:
             self.session.player.load(self.track)
+            self.send("track", self.track.link.uri)
             self.track = None
+
+        if self.playing and (self.session.player.state == spotify.PlayerState.LOADED or
+                        self.session.player.state == spotify.PlayerState.PAUSED):
+            self.send("playing")
+            self.session.player.play()
+
+        if not self.playing and self.session.player.state == spotify.PlayerState.PLAYING:
+            self.send("paused")
+            self.session.player.pause()
+
+    def send(self, *msg):
+        self.status_queue.put(msg)
 
     def command(self, cmd):
         self.cmd_queue.put(cmd)

--- a/musikserver/spotbox.py
+++ b/musikserver/spotbox.py
@@ -13,6 +13,7 @@ class Spotbox:
         self.track = None
         self.audio = spotify.AlsaSink(self.session)
         self.playing = False
+        self.session.on(spotify.SessionEvent.END_OF_TRACK, self.end_of_track)
 
     def run(self):
         timeout = 0
@@ -26,6 +27,11 @@ class Spotbox:
                     t = min(timeout, 100)
                     sleep(t / 1000.0)
             timeout = self.session.process_events()
+
+    def end_of_track(self, not_used):
+        self.session.player.unload()
+        self.send("track")
+        self.send("paused")
 
     def process_command(self, cmd):
         if cmd[0] == "track":


### PR DESCRIPTION
- Add queue for outgoing status events
- Consume queue in server and brodcast events
- Change Spotbox to use threadpool rather than starting it's own thread
